### PR TITLE
Booking page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.34",
         "axios": "^1.9.0",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -6118,6 +6119,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -20838,6 +20848,11 @@
         "is-data-view": "^1.0.1"
       }
     },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+    },
     "debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -27596,6 +27611,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.34",
         "axios": "^1.9.0",
+        "date-fns": "*",
         "gh-pages": "^6.3.0",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
@@ -31831,6 +31847,11 @@
             "es-errors": "^1.3.0",
             "is-data-view": "^1.0.1"
           }
+        },
+        "date-fns": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+          "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
         },
         "debug": {
           "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.34",
     "axios": "^1.9.0",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/Booking/BookingModal.tsx
+++ b/src/components/Booking/BookingModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import {
+  ModalOverlay,
+  ModalWrapper,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalText,
+  ModalButton,
+  RecurringToggle,
+  RecurringLabel,
+} from '../../styles/Booking/BookingModal'
+
+interface BookingModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: (recurring: boolean) => void
+  sessionTime: string
+  isUnbooking?: boolean
+}
+
+const BookingModal: React.FC<BookingModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  sessionTime,
+  isUnbooking = false,
+}) => {
+  const [recurring, setRecurring] = useState(false)
+
+  if (!isOpen) return null
+
+  const handleConfirm = () => {
+    onConfirm(recurring)
+    setRecurring(false)
+  }
+
+  const handleClose = () => {
+    onClose()
+    setRecurring(false)
+  }
+
+  return (
+    <ModalOverlay>
+      <ModalWrapper>
+        <ModalContent>
+          <ModalHeader>Session {isUnbooking ? 'Cancellation' : 'Booking'}</ModalHeader>
+          <ModalBody>
+            <ModalText>
+              {isUnbooking
+                ? `Are you sure you want to cancel the session at ${sessionTime}?`
+                : `Are you sure you want to book the session at ${sessionTime}?`}
+            </ModalText>
+
+            {!isUnbooking && (
+              <RecurringLabel>
+                <RecurringToggle
+                  type="checkbox"
+                  checked={recurring}
+                  onChange={() => setRecurring(prev => !prev)}
+                />
+                Make this a recurring weekly session
+              </RecurringLabel>
+            )}
+          </ModalBody>
+
+          <ModalFooter>
+            <ModalButton $variant="secondary" onClick={handleClose}>
+              No
+            </ModalButton>
+            <ModalButton $variant="primary" onClick={handleConfirm}>
+              Yes
+            </ModalButton>
+          </ModalFooter>
+        </ModalContent>
+      </ModalWrapper>
+    </ModalOverlay>
+  )
+}
+
+export default BookingModal

--- a/src/components/Booking/Calendar.tsx
+++ b/src/components/Booking/Calendar.tsx
@@ -1,0 +1,129 @@
+// src/components/Booking/Calendar.tsx
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import {
+  addMonths,
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  isSameMonth,
+  isSameDay,
+  addDays,
+  subMonths,
+  isToday,
+} from 'date-fns'
+
+const CalendarWrapper = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+`
+
+const CalendarHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+`
+
+const NavButton = styled.button`
+  background: none;
+  border: 1px solid #ccc;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-radius: 5px;
+`
+
+const MonthGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+`
+
+const DayLabel = styled.div`
+  font-weight: bold;
+  text-align: center;
+`
+
+const DayCell = styled.div<{ isToday?: boolean; isCurrentMonth?: boolean }>`
+  background-color: ${({ isToday }) => (isToday ? '#def' : '#fff')};
+  opacity: ${({ isCurrentMonth }) => (isCurrentMonth ? 1 : 0.4)};
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.75rem;
+  text-align: center;
+  cursor: pointer;
+  transition: 0.2s ease;
+
+  &:hover {
+    background-color: #eef;
+  }
+`
+
+const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+const Calendar: React.FC = () => {
+  const today = new Date()
+  const [currentMonth, setCurrentMonth] = useState(startOfMonth(today))
+
+  const renderDays = (month: Date) => {
+    const startDate = startOfWeek(startOfMonth(month))
+    const endDate = endOfWeek(endOfMonth(month))
+    const dayMatrix = []
+    let day = startDate
+
+    while (day <= endDate) {
+      dayMatrix.push(day)
+      day = addDays(day, 1)
+    }
+
+    return dayMatrix.map((dayItem, idx) => (
+      <DayCell
+        key={idx}
+        isToday={isToday(dayItem)}
+        isCurrentMonth={isSameMonth(dayItem, month)}
+      >
+        {format(dayItem, 'd')}
+      </DayCell>
+    ))
+  }
+
+  const renderSixMonths = () => {
+    return Array.from({ length: 6 }).map((_, index) => {
+      const month = addMonths(currentMonth, index)
+      return (
+        <div key={index}>
+          <CalendarHeader>
+            <h3>{format(month, 'MMMM yyyy')}</h3>
+          </CalendarHeader>
+          <MonthGrid>
+            {weekdays.map(day => (
+              <DayLabel key={day}>{day}</DayLabel>
+            ))}
+            {renderDays(month)}
+          </MonthGrid>
+          <hr style={{ margin: '2rem 0' }} />
+        </div>
+      )
+    })
+  }
+
+  return (
+    <CalendarWrapper>
+      <CalendarHeader>
+        <NavButton onClick={() => setCurrentMonth(subMonths(currentMonth, 1))}>
+          Previous
+        </NavButton>
+        <h2>Schedule Calendar</h2>
+        <NavButton onClick={() => setCurrentMonth(addMonths(currentMonth, 1))}>
+          Next
+        </NavButton>
+      </CalendarHeader>
+      {renderSixMonths()}
+    </CalendarWrapper>
+  )
+}
+
+export default Calendar

--- a/src/components/Booking/Schedule.tsx
+++ b/src/components/Booking/Schedule.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import {
+  ScheduleSectionWrapper,
+  ScheduleContainer,
+  WeekGrid,
+  DayHeader,
+  TimeSlot,
+  SlotLabel,
+} from '../../styles/Booking/Schedule'
+
+const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+const times = ['10:00 AM', '11:00 AM', '12:00 PM', '1:00 PM', '2:00 PM', '3:00 PM']
+
+const Schedule = () => {
+  const [bookedSlots, setBookedSlots] = useState<{ [key: string]: boolean }>({})
+
+  const handleSlotClick = (day: string, time: string) => {
+    const key = `${day}-${time}`
+    setBookedSlots(prev => ({
+      ...prev,
+      [key]: !prev[key], // Toggle booked state
+    }))
+  }
+
+  return (
+    <ScheduleSectionWrapper>
+      <ScheduleContainer>
+        <h2>Weekly Schedule</h2>
+        <WeekGrid>
+          <div></div>
+          {days.map(day => (
+            <DayHeader key={day}>{day}</DayHeader>
+          ))}
+
+          {times.map(time => (
+            <React.Fragment key={time}>
+              <SlotLabel>{time}</SlotLabel>
+              {days.map(day => {
+                const key = `${day}-${time}`
+                const isBooked = bookedSlots[key]
+                return (
+                  <TimeSlot
+                    key={key}
+                    booked={isBooked}
+                    onClick={() => handleSlotClick(day, time)}
+                  >
+                    {isBooked ? 'Booked' : 'Available'}
+                  </TimeSlot>
+                )
+              })}
+            </React.Fragment>
+          ))}
+        </WeekGrid>
+      </ScheduleContainer>
+    </ScheduleSectionWrapper>
+  )
+}
+
+export default Schedule

--- a/src/components/Booking/Schedule.tsx
+++ b/src/components/Booking/Schedule.tsx
@@ -1,57 +1,174 @@
 import React, { useState } from 'react'
 import {
+  startOfMonth,
+  addMonths,
+  subMonths,
+  startOfWeek,
+  endOfWeek,
+  endOfMonth,
+  addDays,
+  isSameMonth,
+  isToday,
+  format,
+} from 'date-fns'
+
+import BookingModal from './BookingModal'
+import {
   ScheduleSectionWrapper,
   ScheduleContainer,
-  WeekGrid,
-  DayHeader,
-  TimeSlot,
-  SlotLabel,
+  CalendarHeader,
+  MonthNavButton,
+  MonthTitle,
+  MonthGrid,
+  DayLabel,
+  DayCell,
+  SlotButton,
 } from '../../styles/Booking/Schedule'
 
-const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const times = ['10:00 AM', '11:00 AM', '12:00 PM', '1:00 PM', '2:00 PM', '3:00 PM']
 
 const Schedule = () => {
-  const [bookedSlots, setBookedSlots] = useState<{ [key: string]: boolean }>({})
+  const today = new Date()
+  const [currentMonth, setCurrentMonth] = useState(startOfMonth(today))
+  const [bookedSlots, setBookedSlots] = useState<{ [key: string]: { recurring: boolean } }>({})
+  const [selectedSlot, setSelectedSlot] = useState<{ key: string; label: string } | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [unbooking, setUnbooking] = useState(false)
 
-  const handleSlotClick = (day: string, time: string) => {
-    const key = `${day}-${time}`
-    setBookedSlots(prev => ({
-      ...prev,
-      [key]: !prev[key], // Toggle booked state
-    }))
+  const renderMonth = (month: Date) => {
+    const days = []
+    const start = startOfWeek(startOfMonth(month), { weekStartsOn: 0 }) // Sunday start
+    const end = endOfWeek(endOfMonth(month), { weekStartsOn: 0 }) // Sunday end
+
+    let day = start
+    while (day <= end) {
+      const dateKey = format(day, 'yyyy-MM-dd')
+      const isCurrent = isSameMonth(day, month)
+
+      days.push(
+        <DayCell
+          key={dateKey}
+          isToday={isToday(day)}
+          isCurrentMonth={isCurrent}
+        >
+          <span>{format(day, 'd')}</span>
+          {isCurrent &&
+            times.map(time => {
+              const slotKey = `${dateKey} ${time}`
+              const isSlotBooked = !!bookedSlots[slotKey]
+              return (
+                <SlotButton
+                  key={slotKey}
+                  booked={isSlotBooked}
+                  onClick={() => handleSlotClick(day, time, isSlotBooked)}
+                >
+                  {time}
+                </SlotButton>
+              )
+            })}
+        </DayCell>
+      )
+
+      day = addDays(day, 1)
+    }
+
+    return days
+  }
+
+  const handleSlotClick = (day: Date, time: string, isBooked: boolean) => {
+    const key = `${format(day, 'yyyy-MM-dd')} ${time}`
+    const label = `${format(day, 'PPP')} at ${time}`
+
+    setSelectedSlot({ key, label })
+    setUnbooking(isBooked)
+    setModalOpen(true)
+  }
+
+  const handleModalConfirm = (recurring: boolean) => {
+    if (selectedSlot) {
+      setBookedSlots(prev => ({
+        ...prev,
+        [selectedSlot.key]: { recurring },
+        ...(recurring ? generateRecurringCopies(selectedSlot.key) : {}),
+      }))
+    }
+    closeModal()
+  }
+
+  const handleUnbookConfirm = () => {
+    if (!selectedSlot) return
+
+    const updated = { ...bookedSlots }
+    const isRecurring = bookedSlots[selectedSlot.key]?.recurring
+
+    delete updated[selectedSlot.key]
+
+    if (isRecurring) {
+      for (let i = 1; i <= 3; i++) {
+        const baseDate = new Date(selectedSlot.key.split(' ')[0])
+        const time = selectedSlot.key.split(' ').slice(1).join(' ')
+        const futureDate = addDays(baseDate, i * 7)
+        const recurringKey = `${format(futureDate, 'yyyy-MM-dd')} ${time}`
+        delete updated[recurringKey]
+      }
+    }
+
+    setBookedSlots(updated)
+    closeModal()
+  }
+
+  const generateRecurringCopies = (baseKey: string): {
+    [key: string]: { recurring: boolean }
+  } => {
+    const [datePart, ...timeParts] = baseKey.split(' ')
+    const baseDate = new Date(datePart)
+    const time = timeParts.join(' ')
+    const recurring: { [key: string]: { recurring: boolean } } = {}
+
+    for (let i = 1; i <= 3; i++) {
+      const futureDate = addDays(baseDate, i * 7)
+      const recurringKey = `${format(futureDate, 'yyyy-MM-dd')} ${time}`
+      recurring[recurringKey] = { recurring: true }
+    }
+
+    return recurring
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+    setSelectedSlot(null)
+    setUnbooking(false)
   }
 
   return (
     <ScheduleSectionWrapper>
       <ScheduleContainer>
-        <h2>Weekly Schedule</h2>
-        <WeekGrid>
-          <div></div>
-          {days.map(day => (
-            <DayHeader key={day}>{day}</DayHeader>
-          ))}
+        <CalendarHeader>
+          <MonthNavButton onClick={() => setCurrentMonth(subMonths(currentMonth, 1))}>
+            Prev
+          </MonthNavButton>
+          <MonthTitle>{format(currentMonth, 'MMMM yyyy')}</MonthTitle>
+          <MonthNavButton onClick={() => setCurrentMonth(addMonths(currentMonth, 1))}>
+            Next
+          </MonthNavButton>
+        </CalendarHeader>
 
-          {times.map(time => (
-            <React.Fragment key={time}>
-              <SlotLabel>{time}</SlotLabel>
-              {days.map(day => {
-                const key = `${day}-${time}`
-                const isBooked = bookedSlots[key]
-                return (
-                  <TimeSlot
-                    key={key}
-                    booked={isBooked}
-                    onClick={() => handleSlotClick(day, time)}
-                  >
-                    {isBooked ? 'Booked' : 'Available'}
-                  </TimeSlot>
-                )
-              })}
-            </React.Fragment>
+        <MonthGrid>
+          {weekdays.map(day => (
+            <DayLabel key={day}>{day}</DayLabel>
           ))}
-        </WeekGrid>
+          {renderMonth(currentMonth)}
+        </MonthGrid>
       </ScheduleContainer>
+
+      <BookingModal
+        isOpen={modalOpen}
+        onClose={closeModal}
+        onConfirm={unbooking ? handleUnbookConfirm : handleModalConfirm}
+        sessionTime={selectedSlot?.label || ''}
+        isUnbooking={unbooking}
+      />
     </ScheduleSectionWrapper>
   )
 }

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -1,13 +1,49 @@
-// src/pages/Booking.tsx
-import React from 'react';
+import React, { useState } from 'react'
+import Schedule from '../components/Booking/Schedule'
+import {
+  BookingWrapper,
+  BookingHeader,
+  BookingText,
+  AuthActions,
+  AuthButton,
+  ToggleButton,
+} from '../styles/Booking/Booking'
 
 const Booking = () => {
-  return (
-    <div>
-      <h1>Book a Session</h1>
-      <p>This page will allow logged-in users to schedule a coaching session.</p>
-    </div>
-  );
-};
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
 
-export default Booking;
+  const toggleLogin = () => setIsLoggedIn(prev => !prev)
+
+  return (
+    <BookingWrapper>
+      <ToggleButton onClick={toggleLogin}>
+        {isLoggedIn ? 'Switch to Logged Out View' : 'Switch to Logged In View'}
+      </ToggleButton>
+
+      {isLoggedIn ? (
+        <>
+          <BookingHeader>Book a Session</BookingHeader>
+          <BookingText>
+            Welcome back! Select a time slot below to reserve your coaching session.
+          </BookingText>
+          <Schedule />
+        </>
+      ) : (
+        <>
+          <BookingHeader>Become a Student</BookingHeader>
+          <BookingText>
+            To book lessons, please log in or sign up for an account.
+            <br />
+            If you experience any issues, contact JP via the Contact page or by phone/email.
+          </BookingText>
+          <AuthActions>
+            <AuthButton to="/login">Login</AuthButton>
+            <AuthButton to="/signup">Sign Up</AuthButton>
+          </AuthActions>
+        </>
+      )}
+    </BookingWrapper>
+  )
+}
+
+export default Booking

--- a/src/styles/Booking/Booking.ts
+++ b/src/styles/Booking/Booking.ts
@@ -1,0 +1,62 @@
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+export const BookingWrapper = styled.section`
+  background-color: ${({ theme }) => theme.colours.background};
+  padding: ${({ theme }) => theme.spacing.section} 0;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: ${({ theme }) => theme.spacing.container};
+  padding-right: ${({ theme }) => theme.spacing.container};
+  text-align: center;
+`
+
+export const ToggleButton = styled.button`
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  background-color: #333;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+`
+
+export const BookingHeader = styled.h1`
+  font-size: ${({ theme }) => theme.fontSizes.heading};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  color: ${({ theme }) => theme.colours.text};
+  margin-bottom: 1rem;
+`
+
+export const BookingText = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.body};
+  color: ${({ theme }) => theme.colours.subtext};
+  max-width: 700px;
+  margin: 0 auto 2rem auto;
+  line-height: 1.6;
+`
+
+export const AuthActions = styled.div`
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+`
+
+export const AuthButton = styled(Link)`
+  padding: 0.75rem 1.5rem;
+  background-color: ${({ theme }) => theme.colours.primary};
+  color: white;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background 0.3s;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colours.secondary};
+  }
+`

--- a/src/styles/Booking/BookingModal.ts
+++ b/src/styles/Booking/BookingModal.ts
@@ -1,0 +1,109 @@
+import styled from 'styled-components'
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export const ModalWrapper = styled.div`
+  background-color: ${({ theme }) => theme.colours.white};
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  max-width: 500px;
+  width: 90%;
+  padding: 2rem;
+  z-index: 1001;
+  animation: fadeIn 0.3s ease;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`
+
+export const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`
+
+export const ModalHeader = styled.h3`
+  font-size: ${({ theme }) => theme.fontSizes.subheading};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  color: ${({ theme }) => theme.colours.text};
+  text-align: center;
+`
+
+export const ModalBody = styled.div`
+  text-align: center;
+`
+
+export const ModalText = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.body};
+  color: ${({ theme }) => theme.colours.subtext};
+  line-height: 1.6;
+`
+
+export const RecurringLabel = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1rem;
+  gap: 0.5rem;
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  color: ${({ theme }) => theme.colours.text};
+  user-select: none;
+  cursor: pointer;
+`
+
+export const RecurringToggle = styled.input`
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+`
+
+export const ModalFooter = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+`
+
+export const ModalButton = styled.button<{ $variant: 'primary' | 'secondary' }>`
+  padding: 0.65rem 1.5rem;
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSizes.body};
+  transition: all 0.2s ease-in-out;
+
+  ${({ $variant, theme }) =>
+    $variant === 'primary'
+      ? `
+    background-color: ${theme.colours.primary};
+    color: ${theme.colours.white};
+
+    &:hover {
+      background-color: ${theme.colours.secondary};
+    }
+  `
+      : `
+    background-color: ${theme.colours.surface};
+    color: ${theme.colours.text};
+
+    &:hover {
+      background-color: ${theme.colours.accent};
+    }
+  `}
+`

--- a/src/styles/Booking/Schedule.ts
+++ b/src/styles/Booking/Schedule.ts
@@ -1,0 +1,67 @@
+import styled from 'styled-components'
+
+export const ScheduleSectionWrapper = styled.section`
+  background-color: ${({ theme }) => theme.colours.background};
+  padding: ${({ theme }) => theme.spacing.section} 0;
+`
+
+export const ScheduleContainer = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 ${({ theme }) => theme.spacing.container};
+  text-align: center;
+
+  h2 {
+    font-size: ${({ theme }) => theme.fontSizes.heading};
+    font-weight: ${({ theme }) => theme.fontWeights.bold};
+    color: ${({ theme }) => theme.colours.text};
+    margin-bottom: 2rem;
+  }
+`
+
+export const WeekGrid = styled.div`
+  display: grid;
+  grid-template-columns: 100px repeat(5, 1fr);
+  gap: 0.75rem;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    grid-template-columns: 80px repeat(5, 1fr);
+    overflow-x: auto;
+  }
+`
+
+export const DayHeader = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  text-align: center;
+  padding: 0.5rem 0;
+  background-color: ${({ theme }) => theme.colours.surface};
+  border-radius: 0.5rem;
+  color: ${({ theme }) => theme.colours.text};
+`
+
+export const SlotLabel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  color: ${({ theme }) => theme.colours.subtext};
+`
+
+export const TimeSlot = styled.button<{ booked?: boolean }>`
+  padding: 0.75rem;
+  background-color: ${({ booked, theme }) =>
+    booked ? theme.colours.subtext : theme.colours.primary};
+  color: ${({ booked, theme }) =>
+    booked ? theme.colours.text : theme.colours.white};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background-color: ${({ booked, theme }) =>
+      booked ? theme.colours.subtext : theme.colours.secondary};
+  }
+`

--- a/src/styles/Booking/Schedule.ts
+++ b/src/styles/Booking/Schedule.ts
@@ -19,44 +19,93 @@ export const ScheduleContainer = styled.div`
   }
 `
 
-export const WeekGrid = styled.div`
-  display: grid;
-  grid-template-columns: 100px repeat(5, 1fr);
-  gap: 0.75rem;
-
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
-    grid-template-columns: 80px repeat(5, 1fr);
-    overflow-x: auto;
-  }
+export const CalendarHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
 `
 
-export const DayHeader = styled.div`
+export const MonthTitle = styled.h3`
+  font-size: ${({ theme }) => theme.fontSizes.subheading};
   font-weight: ${({ theme }) => theme.fontWeights.medium};
-  font-size: ${({ theme }) => theme.fontSizes.small};
-  text-align: center;
-  padding: 0.5rem 0;
-  background-color: ${({ theme }) => theme.colours.surface};
-  border-radius: 0.5rem;
   color: ${({ theme }) => theme.colours.text};
 `
 
-export const SlotLabel = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
+export const MonthNavButton = styled.button`
+  background-color: ${({ theme }) => theme.colours.primary};
+  color: ${({ theme }) => theme.colours.white};
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
   font-size: ${({ theme }) => theme.fontSizes.small};
-  color: ${({ theme }) => theme.colours.subtext};
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colours.secondary};
+  }
 `
 
-export const TimeSlot = styled.button<{ booked?: boolean }>`
-  padding: 0.75rem;
+export const MonthGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.75rem;
+`
+
+export const DayLabel = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  color: ${({ theme }) => theme.colours.subtext};
+  text-align: center;
+`
+
+export const DayCell = styled.div<{
+  isToday?: boolean
+  isCurrentMonth?: boolean
+  booked?: boolean
+}>`
+  background-color: ${({ isToday, theme }) =>
+    isToday ? theme.colours.accent : theme.colours.surface};
+  color: ${({ isCurrentMonth, theme }) =>
+    isCurrentMonth ? theme.colours.text : theme.colours.subtext};
+  padding: 1rem;
+  border-radius: 0.5rem;
+  text-align: center;
+  cursor: pointer;
+  box-shadow: ${({ booked }) =>
+    booked ? 'inset 0 0 0 2px #2ecc71' : 'inset 0 0 0 1px rgba(0, 0, 0, 0.05)'};
+  transition: background 0.2s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colours.primary};
+    color: white;
+  }
+
+  span {
+    font-size: 1rem;
+    font-weight: 500;
+    display: block;
+    margin-bottom: 0.25rem;
+  }
+
+  small {
+    font-size: 0.75rem;
+    color: ${({ theme }) => theme.colours.subtext};
+  }
+`
+export const SlotButton = styled.button<{ booked?: boolean }>`
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border: none;
+  border-radius: 0.25rem;
   background-color: ${({ booked, theme }) =>
     booked ? theme.colours.subtext : theme.colours.primary};
   color: ${({ booked, theme }) =>
     booked ? theme.colours.text : theme.colours.white};
-  font-size: ${({ theme }) => theme.fontSizes.small};
-  border: none;
-  border-radius: 0.5rem;
   cursor: pointer;
   transition: background 0.2s ease;
 


### PR DESCRIPTION
feat: implement interactive monthly calendar with booking slots and modal confirmation

- Replaced static weekly Schedule.tsx with dynamic monthly calendar layout
  - Uses date-fns to render accurate days, start on correct weekdays, and fill out full monthly grids 
  - Includes navigation between months and automatic highlighting of the current day

- Added support for booking and unbooking individual time slots within each calendar day (This does not work as expected right now, but with the backend implemented, it will) 
  - Slots displayed per day: 10:00 AM to 3:00 PM
  - Clicking on a slot opens a modal to confirm or cancel the booking
  - Recurring session logic implemented with real calendar dates (e.g. +7, +14, +21 days)

- Updated BookingModal.tsx to handle confirmation logic and optional recurring booking toggle
  - Accepts props for recurring flag, cancel vs. book mode, and displays appropriate messages

- Enhanced Schedule.styles.ts with:
  - DayCell styling for current vs. non-current months (greyed out, non-clickable)
  - Expanded layout for day cells to accommodate multiple slots
  - Responsive SlotButton components for each time

These changes establish a complete scheduling foundation with a clean visual calendar and intuitive interaction model. Ready for backend integration. 