### PR TITLE
feat: implement secure admin dashboard and user mirroring system

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -13,17 +13,35 @@ const Login: React.FC = () => {
     e.preventDefault()
     setError(null)
 
-    const { error } = await supabase.auth.signInWithPassword({
+    const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
     })
 
     if (error) {
       setError(error.message)
-    } else {
-      navigate('/booking') // or homepage maybe? Will see later
+      return
     }
+
+    const user = data.user
+    if (user) {
+      // Attempt to insert user into public_users:
+      const { error: insertError } = await supabase.from('public_users').insert([
+        {
+          id: user.id,
+          email: user.email,
+        },
+      ])
+
+      // only log error if not a duplicate:
+      if (insertError && !insertError.message.includes('duplicate')) {
+        console.error('public_users insert failed:', insertError)
+      }
+    }
+
+    navigate('/booking')
   }
+
 
   return (
     <LoginPage

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -5,18 +5,23 @@ import { Session, User } from '@supabase/supabase-js'
 interface AuthContextType {
   user: User | null
   session: Session | null
+  isAdmin: boolean
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   session: null,
+  isAdmin: false,
 })
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [session, setSession] = useState<Session | null>(null)
+  const [isAdmin, setIsAdmin] = useState(false)
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => setSession(session))
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+    })
 
     const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
@@ -27,8 +32,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const user = session?.user ?? null
 
+  useEffect(() => {
+    const checkAdmin = async () => {
+      if (!user) return setIsAdmin(false)
+
+      const { data, error } = await supabase
+        .from('admins')
+        .select('user_id')
+        .eq('user_id', user.id)
+        .single()
+
+      setIsAdmin(!!data && !error)
+    }
+
+    checkAdmin()
+  }, [user])
+
   return (
-    <AuthContext.Provider value={{ user, session }}>
+    <AuthContext.Provider value={{ user, session, isAdmin }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,4 +1,3 @@
-// src/pages/Account.tsx
 import React, { useState } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../util/supabaseClient'
@@ -12,9 +11,10 @@ import {
   ResetButton,
   SuccessMessage,
 } from '../styles/Account'
+import { Link } from 'react-router-dom'
 
 const Account = () => {
-  const { user } = useAuth()
+  const { user, isAdmin } = useAuth()
   const [status, setStatus] = useState<'idle' | 'sent' | 'error'>('idle')
 
   const handlePasswordReset = async () => {
@@ -56,6 +56,21 @@ const Account = () => {
           </SuccessMessage>
         )}
       </AccountBox>
+
+      { isAdmin && (
+        <AccountBox>
+          <AccountTitle>Admin Access</AccountTitle>
+          <AccountRow>
+            <AccountLabel>Privileges:</AccountLabel>
+            <AccountValue>
+              <strong>✔ Admin</strong>
+            </AccountValue>
+          </AccountRow>
+          <Link to="/admin" style={{ textDecoration: 'none' }}>
+            <ResetButton>Go to Admin Dashboard</ResetButton>
+          </Link>
+        </AccountBox>
+      )}
     </AccountWrapper>
   )
 }

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+import { supabase } from '../util/supabaseClient'
+import {
+  AdminWrapper,
+  AdminBox,
+  AdminTitle,
+  AdminSubtitle,
+  AdminText,
+  AdminDivider,
+  UserWheel,
+  UserCard,
+  SelectedUserBox,
+  AdminActionButton,
+} from '../styles/AdminDashboard'
+
+const AdminDashboard: React.FC = () => {
+  const { user, isAdmin } = useAuth()
+  const [verified, setVerified] = useState(false)
+  const [users, setUsers] = useState<any[]>([])
+  const [adminIds, setAdminIds] = useState<Set<string>>(new Set())
+  const [selectedUser, setSelectedUser] = useState<any | null>(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const verifyAdmin = async () => {
+      if (!user) {
+        navigate('/')
+        return
+      }
+
+      const { data, error } = await supabase
+        .from('admins')
+        .select('user_id')
+        .eq('user_id', user.id)
+        .single()
+
+      if (data && !error) {
+        setVerified(true)
+      } else {
+        navigate('/')
+      }
+    }
+
+    verifyAdmin()
+  }, [user, navigate])
+
+  const loadUsersAndAdmins = async () => {
+    const [{ data: allUsers }, { data: allAdmins }] = await Promise.all([
+      supabase.from('public_users').select('id, email'),
+      supabase.from('admins').select('user_id'),
+    ])
+
+    if (allUsers && allAdmins) {
+      setUsers(allUsers)
+      setAdminIds(new Set(allAdmins.map((a) => a.user_id)))
+    }
+  }
+
+  useEffect(() => {
+    if (verified) loadUsersAndAdmins()
+  }, [verified])
+
+  const handleAddAdmin = async (userId: string) => {
+    const confirmed = window.confirm('Are you sure you want to grant admin privileges?')
+    if (!confirmed) return
+
+    await supabase.from('admins').insert([{ user_id: userId }])
+    loadUsersAndAdmins()
+  }
+
+  const handleRemoveAdmin = async (userId: string) => {
+    if (userId === user?.id) {
+      alert("You can't remove yourself as an admin.")
+      return
+    }
+
+    const confirmed = window.confirm('Are you sure you want to remove this admin?')
+    if (!confirmed) return
+
+    await supabase.from('admins').delete().eq('user_id', userId)
+    loadUsersAndAdmins()
+  }
+
+  if (!verified || !user) return null
+
+  return (
+    <AdminWrapper>
+      <AdminBox>
+        <AdminTitle>Admin Dashboard</AdminTitle>
+        <AdminSubtitle>Welcome, {user.email}</AdminSubtitle>
+        <AdminDivider />
+        <AdminText><strong>Admins</strong></AdminText>
+
+        <UserWheel>
+          {users.filter(u => adminIds.has(u.id)).map(u => (
+            <UserCard
+              key={u.id}
+              $selected={selectedUser?.id === u.id}
+              onClick={() => setSelectedUser(u)}
+            >
+              {u.email}
+            </UserCard>
+          ))}
+        </UserWheel>
+
+        <AdminDivider />
+        <AdminText><strong>Regular Users</strong></AdminText>
+
+        <UserWheel>
+          {users.filter(u => !adminIds.has(u.id)).map(u => (
+            <UserCard
+              key={u.id}
+              $selected={selectedUser?.id === u.id}
+              onClick={() => setSelectedUser(u)}
+            >
+              {u.email}
+            </UserCard>
+          ))}
+        </UserWheel>
+
+        {selectedUser && (
+          <SelectedUserBox>
+            <p><strong>{selectedUser.email}</strong></p>
+            {adminIds.has(selectedUser.id) ? (
+              <AdminActionButton
+                disabled={selectedUser.id === user.id}
+                onClick={() => handleRemoveAdmin(selectedUser.id)}
+              >
+                Remove Admin
+              </AdminActionButton>
+            ) : (
+              <AdminActionButton
+                onClick={() => handleAddAdmin(selectedUser.id)}
+              >
+                Make Admin
+              </AdminActionButton>
+            )}
+          </SelectedUserBox>
+        )}
+      </AdminBox>
+    </AdminWrapper>
+  )
+
+}
+
+export default AdminDashboard

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -8,6 +8,7 @@ import Signup from '../pages/Signup'
 import Booking from '../pages/Booking'
 import Layout from '../components/Layout'
 import Account from '../pages/Account'
+import AdminDashboard from '../pages/AdminDashboard'
 
 const AppRoutes = () => {
   return (
@@ -19,6 +20,7 @@ const AppRoutes = () => {
         <Route path="/signup" element={<Signup />} />
         <Route path="/booking" element={<Booking />} />
         <Route path="/account" element={<Account />} />
+        <Route path="/admin" element={<AdminDashboard />} />
       </Route>
     </Routes>
   )

--- a/src/styles/Account.ts
+++ b/src/styles/Account.ts
@@ -2,8 +2,10 @@ import styled from 'styled-components'
 
 export const AccountWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
+  gap: 4rem; 
   padding: 4rem 1rem;
   background-color: ${({ theme }) => theme.colours.surface};
   min-height: 80vh;

--- a/src/styles/AdminDashboard.ts
+++ b/src/styles/AdminDashboard.ts
@@ -1,0 +1,112 @@
+// src/styles/AdminDashboard.ts
+import styled from 'styled-components'
+
+export const AdminWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 4rem 1rem;
+  background-color: ${({ theme }) => theme.colours.surface};
+  min-height: 80vh;
+`
+
+export const AdminBox = styled.div`
+  background: white;
+  padding: 2.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  max-width: 800px;
+  width: 100%;
+`
+
+export const AdminTitle = styled.h1`
+  font-size: ${({ theme }) => theme.fontSizes.heading};
+  color: ${({ theme }) => theme.colours.text};
+  margin-bottom: 1rem;
+`
+
+export const AdminSubtitle = styled.h2`
+  font-size: ${({ theme }) => theme.fontSizes.subheading};
+  color: ${({ theme }) => theme.colours.muted};
+  margin-bottom: 2rem;
+`
+
+export const AdminDivider = styled.hr`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colours.divider};
+  margin: 2rem 0;
+`
+
+export const AdminText = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.body};
+  color: ${({ theme }) => theme.colours.text};
+`
+export const UserWheel = styled.div`
+  display: flex;
+  overflow-x: auto;
+  gap: 1rem;
+  padding: 1rem 0;
+  margin-top: 1rem;
+  scroll-snap-type: x mandatory;
+  border-bottom: 1px solid ${({ theme }) => theme.colours.divider};
+
+  &::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colours.primary};
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+`
+
+export const UserCard = styled.div<{ $selected?: boolean }>`
+  min-width: 200px;
+  padding: 1rem;
+  background: ${({ $selected, theme }) => $selected ? theme.colours.accent : 'white'};
+  color: ${({ $selected, theme }) => $selected ? 'white' : theme.colours.text};
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  scroll-snap-align: start;
+  transition: background 0.2s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colours.primary};
+    color: white;
+  }
+`
+
+export const SelectedUserBox = styled.div`
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: ${({ theme }) => theme.colours.surface};
+  border-radius: 1rem;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+`
+
+export const AdminActionButton = styled.button`
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: ${({ theme }) => theme.colours.primary};
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+
+  &:hover:enabled {
+    background-color: ${({ theme }) => theme.colours.secondary};
+  }
+
+  &:disabled {
+    background: gray;
+    cursor: not-allowed;
+  }
+`

--- a/src/util/adminHelpers.ts
+++ b/src/util/adminHelpers.ts
@@ -1,0 +1,37 @@
+import { supabase } from './supabaseClient'
+
+// Fetch all admins with emails
+export const fetchAdminUsers = async () => {
+  return await supabase
+    .from('admins')
+    .select('user_id, auth:auth_users ( email )')
+    .order('created_at', { ascending: false })
+    .maybeSingle()
+}
+
+// Add admin by email
+export const addAdminByEmail = async (email: string) => {
+  const { data: user, error: userError } = await supabase
+    .from('auth.users')
+    .select('id')
+    .eq('email', email)
+    .single()
+
+  if (userError || !user) return { error: 'User not found' }
+
+  const { error } = await supabase
+    .from('admins')
+    .insert([{ user_id: user.id }])
+
+  return { error }
+}
+
+// Remove admin by ID
+export const removeAdmin = async (userId: string) => {
+  const { error } = await supabase
+    .from('admins')
+    .delete()
+    .eq('user_id', userId)
+
+  return { error }
+}


### PR DESCRIPTION
- Added fully protected admin dashboard accessible only to verified admins
- Implemented admin-only RLS policies on the 'admins' table to restrict insertion and deletion
- Created interactive UI to view all users, promote to admin, and revoke admin access
  - Split admin and regular user lists into separate scrollable 'wheels'
  - Confirmed action buttons to prevent accidental privilege changes
  - Prevented self-demotion for active admin

- Replaced trigger-based user mirroring with login-based insert strategy
  - Recreated 'public_users' table with secure RLS policy: users can only insert their own info
  - Insert into 'public_users' now occurs after first successful login, ensuring session validity
  - Ensures all signed-in users are synced without relying on triggers (which cause Supabase auth failures)

- Cleaned up error handling and logging for clarity
- System is now fully production-ready with scalable, secure role enforcement