### PR TITLE
feat: implement admin cancellation email workflow with reason input

### DIFF
--- a/src/components/Booking/AdminCancelModal.tsx
+++ b/src/components/Booking/AdminCancelModal.tsx
@@ -1,5 +1,5 @@
 // src/components/Booking/AdminCancelModal.tsx
-import React from 'react'
+import React, { useState } from 'react'
 import {
   ModalOverlay,
   ModalWrapper,
@@ -9,12 +9,14 @@ import {
   ModalText,
   ModalFooter,
   CancelButton,
+  MessageInput,
+  CancelFormLabel,
 } from '../../styles/Booking/CancelModal'
 
 interface AdminCancelModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: () => void
+  onConfirm: (message: string) => void
   bookingTime: string
   userEmail: string
 }
@@ -26,25 +28,48 @@ const AdminCancelModal: React.FC<AdminCancelModalProps> = ({
   bookingTime,
   userEmail,
 }) => {
+  const [message, setMessage] = useState('')
+
+  const handleConfirm = () => {
+    if (message.trim()) {
+      onConfirm(message.trim())
+      setMessage('')
+    } else {
+      alert('Please provide a cancellation reason.')
+    }
+  }
+
+  const handleClose = () => {
+    setMessage('')
+    onClose()
+  }
+
   if (!isOpen) return null
 
   return (
-    <ModalOverlay onClick={onClose}>
+    <ModalOverlay onClick={handleClose}>
       <ModalWrapper onClick={(e) => e.stopPropagation()}>
         <ModalContent>
           <ModalHeader>Cancel Booking</ModalHeader>
           <ModalBody>
             <ModalText>
-              Are you sure you want to cancel the session on <strong>{bookingTime}</strong> booked by <strong>{userEmail}</strong>?
+              You're about to cancel <strong>{bookingTime}</strong> for{' '}
+              <strong>{userEmail}</strong>. Please provide a message explaining why:
             </ModalText>
+            <CancelFormLabel htmlFor="cancel-message">Message to user:</CancelFormLabel>
+            <MessageInput
+              id="cancel-message"
+              placeholder="Reason for cancellation..."
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              required
+            />
           </ModalBody>
           <ModalFooter>
-            <CancelButton $secondary onClick={onClose}>
-              Keep Session
+            <CancelButton $secondary onClick={handleClose}>
+              Close
             </CancelButton>
-            <CancelButton onClick={onConfirm}>
-              Cancel Session
-            </CancelButton>
+            <CancelButton onClick={handleConfirm}>Send & Cancel</CancelButton>
           </ModalFooter>
         </ModalContent>
       </ModalWrapper>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import emailjs from '@emailjs/browser'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../util/supabaseClient'
 import { useAdminData } from '../hooks/useAdminData'
 import { useAdminBookings } from '../hooks/useAdminBookings'
+import { sendCancellationEmail } from '../util/sendCancellationEmail'
 import {
   AdminWrapper,
   AdminBox,
@@ -229,8 +231,19 @@ const AdminDashboard: React.FC = () => {
           <AdminCancelModal
             isOpen={modalOpen}
             onClose={() => setModalOpen(false)}
-            onConfirm={() => {
+            onConfirm={(message) => {
               cancelBooking(selectedBooking.id)
+              sendCancellationEmail(
+                selectedBooking.email,
+                selectedBooking.booking_time,
+                message
+              ).then(() => {
+                alert('Cancellation email sent.')
+              }).catch((err) => {
+                console.error('Email failed:', err)
+                alert('Booking was cancelled, but email failed to send.')
+              })
+
               setModalOpen(false)
             }}
             bookingTime={selectedBooking.booking_time}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -26,6 +26,12 @@ const Contact = () => {
 
     if (!form.current) return
 
+    console.log(
+      process.env.REACT_APP_EMAILJS_SERVICE_ID,
+      process.env.REACT_APP_EMAIL_JS_TEMPLATE_ID_CancelBooking,
+      process.env.REACT_APP_EMAILJS_PUBLIC_KEY
+    )
+
     emailjs
       .sendForm(
         'service_ky7e9lg',

--- a/src/styles/Booking/CancelModal.ts
+++ b/src/styles/Booking/CancelModal.ts
@@ -71,3 +71,24 @@ export const CheckboxLabel = styled.label`
   font-size: 0.9rem;
   margin-top: 1rem;
 `
+
+export const MessageInput = styled.textarea`
+  width: 100%;
+  height: 100px;
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  resize: vertical;
+  font-family: inherit;
+`
+
+export const CancelFormLabel = styled.label`
+  display: block;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #333;
+`

--- a/src/util/sendCancellationEmail.ts
+++ b/src/util/sendCancellationEmail.ts
@@ -1,0 +1,19 @@
+// src/util/AdminCancelModal.tsx
+import emailjs from '@emailjs/browser'
+
+export const sendCancellationEmail = async (
+  userEmail: string,
+  bookingTime: string,
+  adminMessage: string
+) => {
+  return await emailjs.send(
+    'service_ky7e9lg',               // Service ID
+    'template_ohecpup',              // Template ID for cancel emails
+    {
+      user_email: userEmail,
+      booking_time: bookingTime,
+      admin_message: adminMessage,
+    },
+    'rMl15TPZgw2zfKhYx'              // Public Key
+  )
+}


### PR DESCRIPTION
- Created reusable sendCancellationEmail.ts utility in util/ to send booking cancellation notifications via EmailJS
- Updated AdminDashboard.tsx to handle booking cancellation with email logic
  - Admins now prompted with a modal to provide cancellation reason
  - Reason is required before session can be cancelled
  - Email sent to user after successful cancellation
- Enhanced AdminCancelModal.tsx to collect and validate admin cancellation messages without side effects
- Ensured separation of concerns: UI handles input, dashboard handles logic, util handles email API call

This ensures admins can notify users with a message when cancelling sessions, improving communication and professionalism.